### PR TITLE
Don't require setTimeZone before UTCToWallTime - Fixes #9 

### DIFF
--- a/lib/walltime.coffee
+++ b/lib/walltime.coffee
@@ -22,6 +22,8 @@ init = (helpers, rule, zone) ->
                 newRules = (new rule.Rule(r.name, r._from, r._to, r.type, r.in, r.on, r.at, r._save, r.letter) for r in ruleVals)
                 @rules[ruleName] = newRules
             
+            @zoneSet = null
+            @timeZoneName = null
             @doneInit = true
 
         setTimeZone: (name) ->
@@ -44,11 +46,11 @@ init = (helpers, rule, zone) ->
             if typeof dt == "number"
                 dt = new Date(dt)
 
-            if !@zoneSet
-                throw new Error "Must set the time zone before converting times"
-
             if zoneName != @timeZoneName
                 @setTimeZone zoneName
+
+            if !@zoneSet
+                throw new Error "Must set the time zone before converting times"
 
             @zoneSet.getWallTimeForUTC dt
 

--- a/test/walltime_spec.coffee
+++ b/test/walltime_spec.coffee
@@ -141,6 +141,29 @@ describe "walltime-js", ->
 
         result.wallTime.getTime().should.equal expectWallTime.wallTime.getTime(), "WallTimes: #{result.wallTime.toUTCString()} :: #{expectWallTime.wallTime.toUTCString()}"
 
+    describe "UTCToWallTime", ->
+
+        it "can be called before setTimeZone as long as zone is passed", ->
+            WallTime.init rules, zones
+
+            currTime = new Date().getTime()
+
+            result = WallTime.UTCToWallTime currTime, "America/Chicago"
+
+            should.exist result
+
+        it "throws an error when you don't setTimeZone and don't pass a zone", ->
+            WallTime.init rules, zones
+
+            currTime = new Date().getTime()
+            result = null
+
+            callFunc = ->
+                result = WallTime.UTCToWallTime currTime
+
+            callFunc.should.throw()
+            should.not.exist result
+
     describe "UTCToWallTime (America/Chicago)", ->
         before (next) ->
             readTimezoneFile "./test/rsrc/full/northamerica", next


### PR DESCRIPTION
Some small changes to match expected behavior when you pass in a zone name to UTCToWallTime.
