### PR TITLE
Add a --minyear parameter, to truncate obsolte rules/zones

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -112,7 +112,7 @@ buildDataFile = (opts, callback) ->
   opts.filename or= []
   opts.zonename or= []
   opts.outputname or= "./client/walltime-data.js"
-  opts.minyear = opts.minyear && parseInt(opts.minyear, 10) || -9999
+  opts.minyear = parseInt opts.minyear || "-271821", 10
 
   allFiles = true
   filesToProcess = {}


### PR DESCRIPTION
I've added a --minyear option. With it, `cake -y 2010 data` will build a `client/walltime-data.js` of 74kb, `walltime-data.min.js` of 66kb, and gzip-compressed data of 9 kb.
