### PR TITLE
Move some deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "coffee-script": "~1.6.1",
     "mocha": "~1.x.x",
     "line-reader": "~0.2.1",
-    "strscan": "~1.0.1",
-    "requirejs": "~2.0.6"
+    "requirejs": "~2.0.6",
+    "strscan": "~1.0.1"
   },
   "devDependencies": {
     "grunt-bump": "0.0.11",


### PR DESCRIPTION
I just pulled this through npm and it ended up pulling coffee script and should as well.  I'm assuming they are not runtime dependencies.

I _think_ uglify-js is also a build-time concern, so devDependencies should be sufficient?  

I'm not familiar enough with requirejs or how you are using line-reader or strscan to know where those belong, but I'm pretty sure that these 3 don't need to be pulled down into my project that is just trying to use walltime.
